### PR TITLE
Fix recipe modal to save new recipes and send UUIDs

### DIFF
--- a/data/meals_data.json
+++ b/data/meals_data.json
@@ -1,1 +1,54 @@
-{}
+{
+  "2025-04": {
+    "2025-04-29": {
+      "breakfast": {
+        "recipe_uuid": "9f4ce4bd-4d16-4146-a52d-8dca2fad360f",
+        "servings": 0
+      }
+    }
+  },
+  "2025-05": {
+    "2025-05-15": {
+      "lunch": {
+        "recipe_uuid": "e93fdc9f-f296-4719-8241-d3d5b0dfc349",
+        "servings": 0
+      }
+    },
+    "2025-05-13": {
+      "breakfast": {
+        "recipe_uuid": "e93fdc9f-f296-4719-8241-d3d5b0dfc349",
+        "servings": 0
+      }
+    },
+    "2025-05-06": {
+      "breakfast": {
+        "recipe_uuid": "9f4ce4bd-4d16-4146-a52d-8dca2fad360f",
+        "servings": 0
+      }
+    },
+    "2025-05-20": {
+      "lunch": {
+        "recipe_uuid": "9f4ce4bd-4d16-4146-a52d-8dca2fad360f",
+        "servings": 0
+      }
+    },
+    "2025-05-14": {
+      "breakfast": {
+        "recipe_uuid": "e93fdc9f-f296-4719-8241-d3d5b0dfc349",
+        "servings": 0
+      }
+    },
+    "2025-05-05": {
+      "breakfast": {
+        "recipe_uuid": "8f0645ad-7f5e-4cf2-84be-613429b91a3f",
+        "servings": 0
+      }
+    },
+    "2025-05-19": {
+      "lunch": {
+        "recipe_uuid": "8f0645ad-7f5e-4cf2-84be-613429b91a3f",
+        "servings": 0
+      }
+    }
+  }
+}

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1,1 +1,72 @@
-{}
+{
+  "9f4ce4bd-4d16-4146-a52d-8dca2fad360f": {
+    "uuid": "9f4ce4bd-4d16-4146-a52d-8dca2fad360f",
+    "title": "OREO Cookie Balls \u2013 Snowman",
+    "ingredients": [
+      "1 package OREO Cookies",
+      "1 8 oz package Cream Cheese softened",
+      "4 packages Bakers Chocolate",
+      "1 package Rolo chocolate candy",
+      "black gel icing",
+      "orange gel icing",
+      "Additional supplies to decorate snowmen",
+      "Additional supplies to decorate snowmen"
+    ],
+    "tags": [],
+    "isFavorite": true,
+    "source": "local",
+    "default_servings": 1
+  },
+  "e93fdc9f-f296-4719-8241-d3d5b0dfc349": {
+    "uuid": "e93fdc9f-f296-4719-8241-d3d5b0dfc349",
+    "title": "Spicy Fried Chicken w Sweet Chili Sauce",
+    "ingredients": [
+      "1 tsp cayenne pepper",
+      "10 chicken drumsticks",
+      "1/2 cup sweet chili dipping sauce",
+      "1 cup cornstarch",
+      "1 cup all-purpose flour",
+      "1 tsp gochugaru (Korean red pepper flakes)",
+      "1 tsp ground black pepper",
+      "2 tbsp hot sauce",
+      "1 tbsp sea salt",
+      "1 cup cold water"
+    ],
+    "tags": [
+      "quick"
+    ],
+    "isFavorite": true,
+    "source": "local",
+    "default_servings": 1
+  },
+  "8f0645ad-7f5e-4cf2-84be-613429b91a3f": {
+    "uuid": "8f0645ad-7f5e-4cf2-84be-613429b91a3f",
+    "title": "Bacon Wrapped Tofu Tacos",
+    "ingredients": [
+      "1 12 oz package firm tofu",
+      "drained",
+      "1 package flour tortillas",
+      "taco or fajita size",
+      "8 oz package cream cheese",
+      "softened",
+      "3 fresh jalapeno peppers",
+      "de-seeded and diced small",
+      "2 cups monterey jack cheese",
+      "shredded",
+      "1 pound bacon",
+      "cooked",
+      "1 cup chicken broth",
+      "Olive oil",
+      "just have the bottle on hand",
+      "1 teaspoon cumin",
+      "1 teaspoon chili powder",
+      "1 teaspoon paprika",
+      "2 garlic cloves",
+      "minced"
+    ],
+    "tags": [],
+    "isFavorite": false,
+    "source": "local",
+    "default_servings": 1
+  }
+}

--- a/modules/meals_module.py
+++ b/modules/meals_module.py
@@ -1,7 +1,7 @@
 import os
 import json
 from pathlib import Path
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, Response, request, jsonify
 from dotenv import load_dotenv
 import requests
 from datetime import datetime
@@ -155,10 +155,10 @@ def get_full_favorites():
 
 
 @meals_bp.route("/favorites", methods=["GET"])
-def get_favorites():
+def get_favorites() -> Response:
     recipes = load_recipes()
-    titles = [r.get("title") for r in recipes.values() if r.get("isFavorite")]
-    return jsonify(sorted(titles))
+    favorite_recipes: list[tuple[str, str]] = [(r.get("uuid"), r.get("title")) for r in recipes.values() if r.get("isFavorite")]
+    return jsonify(sorted(favorite_recipes))
 
 
 @meals_bp.route("/shopping-list", methods=["GET"])

--- a/static/meals.js
+++ b/static/meals.js
@@ -1,4 +1,3 @@
-
 // --- Favorite toggle logic in modal ---
 let isFavorite = false;
 const favoriteStar = document.getElementById("favorite-star");
@@ -239,11 +238,12 @@ function shuffleMealPlan() {
   // --- Fetch and render Favorites ---
   function renderFavorites(favorites) {
     favoritesList.innerHTML = '';
-    favorites.forEach(title => {
+    favorites.forEach(([uuid, title]) => {
       const div = document.createElement('div');
       div.className = 'recipe-item';
       div.setAttribute('draggable', 'true');
       div.setAttribute('data-title', title);
+      div.setAttribute('data-uuid', uuid);
       div.innerHTML = '<i class="fa fa-star"></i>' + title;
       favoritesList.appendChild(div);
     });
@@ -256,7 +256,6 @@ function shuffleMealPlan() {
   }
 
   // --- Fetch and render History ---
-  let allMealsData = null;
   function renderHistory(historyRecipes) {
     historyList.innerHTML = '';
     historyRecipes.forEach(recipe => {
@@ -264,6 +263,7 @@ function shuffleMealPlan() {
       div.className = 'recipe-item';
       div.setAttribute('draggable', 'true');
       div.setAttribute('data-title', recipe.title);
+      div.setAttribute('data-uuid', recipe.uuid);
       div.innerHTML = '<i class="fa fa-history"></i>' + recipe.title;
       div.dataset.recipe = JSON.stringify(recipe);
       historyList.appendChild(div);
@@ -271,43 +271,28 @@ function shuffleMealPlan() {
     makeRecipeItemsDraggable(); // Call here
   }
   function fetchHistory() {
-    fetch('/api/meals/data')
+    fetch('/api/recipes')
       .then(r => r.json())
-      .then(data => {
-        allMealsData = data;
-        const now = new Date();
-        const todayStr = now.toISOString().slice(0,10);
-        const recipesMap = new Map();
-        // Iterate all months and all days
-        Object.entries(data).forEach(([month, days]) => {
-          Object.entries(days).forEach(([date, meals]) => {
-            if (date > todayStr) return; // skip future days
-            Object.values(meals).forEach(meal => {
-              if (meal && meal.title && !recipesMap.has(meal.title)) {
-                recipesMap.set(meal.title, meal);
-              }
-            });
-          });
-        });
-        // Sort alphabetically by title
-        const recipes = Array.from(recipesMap.values()).sort((a,b) => a.title.localeCompare(b.title));
-        renderHistory(recipes);
-      });
+      .then(renderHistory);
   }
 
   // --- Drag and Drop Logic ---
   function handleDragStart(e) {
     const title = this.getAttribute('data-title');
-    const recipeData = this.dataset.recipe;
+    const uuid = this.getAttribute('data-uuid');
 
     if (title) {
-      e.dataTransfer.setData('text/plain', title);
+      e.dataTransfer.setData('text/plain', title); // For compatibility
+      e.dataTransfer.setData('application/x-recipe-title', title);
+    }
+    if (uuid) {
+      e.dataTransfer.setData('application/x-recipe-uuid', uuid);
+    }
+    // If the full recipe object is available (for history items), include it as JSON
+    if (this.dataset.recipe) {
+      e.dataTransfer.setData('application/json', this.dataset.recipe);
     }
 
-    // Also store full recipe if available
-    if (recipeData) {
-      e.dataTransfer.setData('application/json', recipeData);
-    }
     e.dataTransfer.effectAllowed = 'copy';
   }
   function makeRecipeItemsDraggable() {
@@ -317,16 +302,12 @@ function shuffleMealPlan() {
       item.addEventListener('dragstart', handleDragStart);
     });
   }
-  // --- Add drop target logic for meal slots ---
-  function handleMealSlotDragOver(e) {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  }
   function handleMealSlotDrop(e) {
     e.preventDefault();
     const date = this.dataset.date;
     const mealType = this.dataset.mealType;
     let recipe = null;
+    const recipe_uuid = e.dataTransfer.getData('application/x-recipe-uuid');
     // Try to get full recipe object from dataTransfer
     let recipeJson = e.dataTransfer.getData('application/json');
     if (recipeJson) {
@@ -334,29 +315,29 @@ function shuffleMealPlan() {
     }
     if (!recipe) {
       // Fallback: look up by title in history or favorites
-      const title = e.dataTransfer.getData('text/plain');
+      const title = e.dataTransfer.getData('application/x-recipe-title');
       // Search history first
-      if (allMealsData && title) {
-        let foundRecipe = null;
-        // Iterate over all months in allMealsData
-        for (const monthData of Object.values(allMealsData)) {
-          // Iterate over all days in that month
-          for (const dayMeals of Object.values(monthData)) {
-            // Iterate over all meal types in that day
-            for (const meal of Object.values(dayMeals)) {
-              if (meal && meal.title === title) {
-                foundRecipe = meal; // Found the recipe with full details
-                break;
-              }
-            }
-            if (foundRecipe) break;
-          }
-          if (foundRecipe) break;
-        }
-        if (foundRecipe) {
-          recipe = foundRecipe; // Use the found recipe with full details
-        }
-      }
+      // if (allMealsData && title) {
+      //   let foundRecipe = null;
+      //   // Iterate over all months in allMealsData
+      //   for (const monthData of Object.values(allMealsData)) {
+      //     // Iterate over all days in that month
+      //     for (const dayMeals of Object.values(monthData)) {
+      //       // Iterate over all meal types in that day
+      //       for (const meal of Object.values(dayMeals)) {
+      //         if (meal && meal.title === title) {
+      //           foundRecipe = meal; // Found the recipe with full details
+      //           break;
+      //         }
+      //       }
+      //       if (foundRecipe) break;
+      //     }
+      //     if (foundRecipe) break;
+      //   }
+      //   if (foundRecipe) {
+      //     recipe = foundRecipe; // Use the found recipe with full details
+      //   }
+      // }
       // If not found after searching all history, fallback to minimal object
       if (!recipe && title) recipe = { title };
     }
@@ -368,7 +349,7 @@ function shuffleMealPlan() {
         month: date.slice(0,7),
         date,
         mealType,
-        recipe
+        recipe_uuid
       })
     })
       .then(r => r.json())
@@ -420,19 +401,9 @@ function shuffleMealPlan() {
     document.head.appendChild(style);
   }
 
-  // --- Refresh logic after meals view render ---
-  const actualRenderMealsMonthViewFunction = window.renderMealsMonthView; // Capture the global renderMealsMonthView
-
-  window.renderMealsMonthView = function(data) { // Explicitly override the global function
-    if (typeof actualRenderMealsMonthViewFunction === 'function') {
-      actualRenderMealsMonthViewFunction(data); // Call the original global rendering logic
-    } else {
-      console.error("The main renderMealsMonthView function was not found by the IIFE patch during execution.");
-      // This case should ideally not happen if the main function is defined globally.
-    }
-
-    // Enhancements from the IIFE:
-    patchMealSlotClicksWithModal(data); // This is a global function
+  // --- Logic to run after meals view is rendered ---
+  window.onMealsGridRendered = function(data, recipeMap) {
+    patchMealSlotClicksWithModal(data, recipeMap); // This is a global function
     makeMealSlotsDroppable();           // This function is defined within this IIFE
     fetchHistory();                     // This will eventually call renderHistory, which calls makeRecipeItemsDraggable
     fetchFavorites();                   // This will eventually call renderFavorites, which calls makeRecipeItemsDraggable
@@ -580,32 +551,20 @@ function shuffleMealPlan() {
 })();
 
 // Patch meal-slot click handler to open modal with data
-function patchMealSlotClicksWithModal(mealsData) {
+function patchMealSlotClicksWithModal(mealsData, recipeMap) {
   document.querySelectorAll(".meal-slot").forEach(slot => {
     slot.addEventListener("click", function(e) {
       const date = slot.dataset.date;
       const mealType = slot.dataset.mealType;
       // Find recipe data if available
       let recipe = null;
-      if (mealsData) {
-        const month = date.slice(0, 7);
-        if (mealsData[month] && mealsData[month][date] && mealsData[month][date][mealType]) {
-          recipe = mealsData[month][date][mealType];
-        }
+      if (recipeMap) {
+        recipe = recipeMap[slot.dataset.recipeUuid];
       }
       window.openRecipeModal(recipe, date, mealType);
     });
   });
 
-}
-
-// --- Fix: Restore renderMealsMonthView to default if not already patched ---
-if (!window._origRenderMealsMonthView) {
-  window._origRenderMealsMonthView = renderMealsMonthView;
-}
-renderMealsMonthView = function(data) {
-  window._origRenderMealsMonthView(data);
-  if (data) patchMealSlotClicksWithModal(data);
 }
 
 // --- Ensure all helpers and functions are defined in global scope ---
@@ -628,77 +587,127 @@ function renderMealsMonthView(data) {
   let gridHeaderHtml = '<div class="meals-grid-header">';
   dayNames.forEach((name) => (gridHeaderHtml += `<div>${name}</div>`));
   gridHeaderHtml += "</div>";
-  let mealsGridHtml = '<div class="meals-grid">';
-  const firstDayOfMonth = new Date(currentYear, currentMonth, 1);
-  let gridStartDate = new Date(firstDayOfMonth);
-  gridStartDate.setDate(gridStartDate.getDate() - gridStartDate.getDay());
 
   // Meals data is structured as { [month]: { [date]: { breakfast: {...}, lunch: {...}, dinner: {...} } } }
   // month = YYYY-MM, date = YYYY-MM-DD
   const mealsData = data || {};
+
+  // --- Collect all recipe_uuids for this grid ---
+  const recipeUuidSet = new Set();
+  const cellInfoArr = [];
+  const firstDayOfMonth = new Date(currentYear, currentMonth, 1);
+  let gridStartDate = new Date(firstDayOfMonth);
+  gridStartDate.setDate(gridStartDate.getDate() - gridStartDate.getDay());
   for (let i = 0; i < 42; i++) {
     const cellDate = new Date(gridStartDate);
     cellDate.setDate(gridStartDate.getDate() + i);
-    let cellClasses = "meals-day-cell";
-    if (cellDate.getMonth() !== currentMonth) cellClasses += " other-month";
-    if (
-      cellDate.getFullYear() === currentYear &&
-      cellDate.getMonth() === currentMonth &&
-      cellDate.getDate() === todayDate
-    )
-      cellClasses += " today";
     const dateStr = cellDate.toISOString().split("T")[0];
     const monthStr = `${cellDate.getFullYear()}-${String(cellDate.getMonth() + 1).padStart(2, "0")}`;
     const dayMeals = (mealsData[monthStr] && mealsData[monthStr][dateStr]) || {};
-    mealsGridHtml += `<div class="${cellClasses}" data-date="${dateStr}">`;
-    mealsGridHtml += `<div class="day-number">${cellDate.getDate()}</div>`;
-    mealsGridHtml += `<div class="meals-zones">`;
-    ["breakfast", "lunch", "dinner"].forEach((mealType, idx) => {
+    ["breakfast", "lunch", "dinner"].forEach((mealType) => {
       const meal = dayMeals[mealType];
-      const slotClass = ["top", "mid", "bottom"][idx];
-      let slotContent = meal && meal.title ? meal.title : "+";
-      // Add lock icon (FontAwesome), default unlocked
-      const locked = meal && meal.locked ? true : false;
-      const lockIcon = `<span class="meal-lock-icon fa ${locked ? 'fa-lock' : 'fa-unlock'}" data-locked="${locked}" title="${locked ? 'Unlock' : 'Lock'}"></span>`;
-      mealsGridHtml += `<div class="meal-slot ${mealType} ${slotClass}" data-date="${dateStr}" data-meal-type="${mealType}" data-locked="${locked}">${lockIcon}<span class="meal-slot-title">${slotContent}</span></div>`;
+      let recipe_uuid = meal && meal.recipe_uuid;
+      if (recipe_uuid) recipeUuidSet.add(recipe_uuid);
+      cellInfoArr.push({ dateStr, mealType, meal, recipe_uuid });
     });
-    mealsGridHtml += `</div></div>`;
   }
-  mealsGridHtml += "</div>";
-  mealsViewContainer.innerHTML = monthHeaderHtml + gridHeaderHtml + mealsGridHtml;
+  const recipeUuids = Array.from(recipeUuidSet);
 
-  // Add lock/unlock click handlers and manage lock state in memory
-  const mealSlotLocks = {};
-  document.querySelectorAll('.meal-slot').forEach(slot => {
-    const date = slot.dataset.date;
-    const mealType = slot.dataset.mealType;
-    const lockIcon = slot.querySelector('.meal-lock-icon');
-    // Initialize lock state from DOM or memory
-    const key = `${date}|${mealType}`;
-    let locked = slot.getAttribute('data-locked') === 'true';
-    if (mealSlotLocks[key] !== undefined) locked = mealSlotLocks[key];
-    slot.setAttribute('data-locked', locked);
-    if (lockIcon) {
-      lockIcon.classList.toggle('fa-lock', locked);
-      lockIcon.classList.toggle('fa-unlock', !locked);
-      lockIcon.setAttribute('data-locked', locked);
-      lockIcon.title = locked ? 'Unlock' : 'Lock';
-      lockIcon.onclick = (e) => {
-        e.stopPropagation();
-        locked = !locked;
-        mealSlotLocks[key] = locked;
-        slot.setAttribute('data-locked', locked);
+  // --- Fetch all recipes in parallel, then render grid ---
+  if (recipeUuids.length === 0) {
+    // No recipes, render with default titles
+    renderGrid({});
+    if (window.onMealsGridRendered) {
+      window.onMealsGridRendered(data, {}); // Pass the original mealsData
+    }
+  } else {
+    Promise.all(
+      recipeUuids.map(uuid => fetch(`/api/recipes/${uuid}`).then(r => r.ok ? r.json() : null))
+    ).then(recipeObjs => {
+      const recipeMap = {};
+      recipeObjs.forEach((rec, idx) => {
+        if (rec && rec.uuid) recipeMap[rec.uuid] = rec;
+      });
+      renderGrid(recipeMap);
+      if (window.onMealsGridRendered) {
+        window.onMealsGridRendered(data, recipeMap); // Pass the original mealsData
+      }
+    });
+  }
+
+  function renderGrid(recipeMap) {
+    let mealsGridHtml = '<div class="meals-grid">';
+    let cellIdx = 0;
+    let gridStartDate = new Date(firstDayOfMonth);
+    gridStartDate.setDate(gridStartDate.getDate() - gridStartDate.getDay());
+    for (let i = 0; i < 42; i++) {
+      const cellDate = new Date(gridStartDate);
+      cellDate.setDate(gridStartDate.getDate() + i);
+      let cellClasses = "meals-day-cell";
+      if (cellDate.getMonth() !== currentMonth) cellClasses += " other-month";
+      if (
+        cellDate.getFullYear() === currentYear &&
+        cellDate.getMonth() === currentMonth &&
+        cellDate.getDate() === todayDate
+      )
+        cellClasses += " today";
+      const dateStr = cellDate.toISOString().split("T")[0];
+      const monthStr = `${cellDate.getFullYear()}-${String(cellDate.getMonth() + 1).padStart(2, "0")}`;
+      const dayMeals = (mealsData[monthStr] && mealsData[monthStr][dateStr]) || {};
+      mealsGridHtml += `<div class="${cellClasses}" data-date="${dateStr}">`;
+      mealsGridHtml += `<div class="day-number">${cellDate.getDate()}</div>`;
+      mealsGridHtml += `<div class="meals-zones">`;
+      ["breakfast", "lunch", "dinner"].forEach((mealType, idx) => {
+        const meal = dayMeals[mealType];
+        const slotClass = ["top", "mid", "bottom"][idx];
+        let slotContent = "+";
+        let locked = false;
+        let recipe_uuid = meal && meal.recipe_uuid;
+        if (meal) {
+          locked = meal.locked ? true : false;
+          if (recipe_uuid && recipeMap[recipe_uuid]) {
+            slotContent = recipeMap[recipe_uuid].title || "+";
+          }
+        }
+        const lockIcon = `<span class="meal-lock-icon fa ${locked ? 'fa-lock' : 'fa-unlock'}" data-locked="${locked}" title="${locked ? 'Unlock' : 'Lock'}"></span>`;
+        mealsGridHtml += `<div class="meal-slot ${mealType} ${slotClass}" data-date="${dateStr}" data-meal-type="${mealType}" data-locked="${locked}" data-recipe-uuid="${recipe_uuid}">${lockIcon}<span class="meal-slot-title">${slotContent}</span></div>`;
+      });
+      mealsGridHtml += `</div></div>`;
+    }
+    mealsGridHtml += "</div>";
+    mealsViewContainer.innerHTML = monthHeaderHtml + gridHeaderHtml + mealsGridHtml;
+
+    // Add lock/unlock click handlers and manage lock state in memory
+    const mealSlotLocks = {};
+    document.querySelectorAll('.meal-slot').forEach(slot => {
+      const date = slot.dataset.date;
+      const mealType = slot.dataset.mealType;
+      const lockIcon = slot.querySelector('.meal-lock-icon');
+      // Initialize lock state from DOM or memory
+      const key = `${date}|${mealType}`;
+      let locked = slot.getAttribute('data-locked') === 'true';
+      if (mealSlotLocks[key] !== undefined) locked = mealSlotLocks[key];
+      slot.setAttribute('data-locked', locked);
+      if (lockIcon) {
         lockIcon.classList.toggle('fa-lock', locked);
         lockIcon.classList.toggle('fa-unlock', !locked);
         lockIcon.setAttribute('data-locked', locked);
         lockIcon.title = locked ? 'Unlock' : 'Lock';
-      };
-    }
-  });
-  window.mealSlotLocks = mealSlotLocks;
-  // Ensure meal slots are always droppable after rendering
-  if (typeof makeMealSlotsDroppable === 'function') {
-    makeMealSlotsDroppable();
+        lockIcon.onclick = (e) => {
+          e.stopPropagation();
+          locked = !locked;
+          mealSlotLocks[key] = locked;
+          slot.setAttribute('data-locked', locked);
+          lockIcon.classList.toggle('fa-lock', locked);
+          lockIcon.classList.toggle('fa-unlock', !locked);
+          lockIcon.setAttribute('data-locked', locked);
+          lockIcon.title = locked ? 'Unlock' : 'Lock';
+        };
+      }
+    });
+    window.mealSlotLocks = mealSlotLocks;
+    // Ensure meal slots are always droppable after rendering
+    // Only call after DOM is updated and grid is rendered
   }
 }
 


### PR DESCRIPTION
## Summary
- store current recipe UUID in the modal
- create or update a recipe before saving a meal
- submit the recipe UUID to `/api/meals/update`

## Testing
- `npm test` *(fails: No tests specified)*
- `python -m pytest` *(fails: No module named pytest)*