### PR TITLE
Implement multi-day events for FamilyDASH calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 logs/
 __pycache__/
 .venv/
+venv/
+node_modules/
+package-lock.json
 cookies/
 *.pyc

--- a/modules/icloud_module.py
+++ b/modules/icloud_module.py
@@ -199,6 +199,36 @@ def get_icloud_data():
                         "attendees": attendees_list,
                     }
                 )
+
+        # Insert a couple of multi-day events that span across the grid
+        multi_timed_start = today.replace(hour=6, minute=0, second=0, microsecond=0)
+        multi_timed_end = multi_timed_start + timedelta(days=2, hours=6)
+        stub_events.append(
+            {
+                "uid": "stub-multi-timed",
+                "title": "Conference Trip",
+                "start": multi_timed_start.isoformat(),
+                "end": multi_timed_end.isoformat(),
+                "calendar": random.choice(calendar_names),
+                "color": random.choice(list(calendar_colors.values())),
+                "notes": "Offsite conference with sessions",
+            }
+        )
+
+        multi_all_start = today.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
+        multi_all_end = multi_all_start + timedelta(days=4)
+        stub_events.append(
+            {
+                "uid": "stub-multi-all-day",
+                "title": "Family Vacation",
+                "start": multi_all_start.isoformat(),
+                "end": multi_all_end.isoformat(),
+                "calendar": random.choice(calendar_names),
+                "color": random.choice(list(calendar_colors.values())),
+                "allDay": True,
+                "notes": "Trip with overlap",
+            }
+        )
         stub_data = {
             "user": os.getenv("ICLOUD_USERNAME", "dev_user"),
             "calendars": [{"name": name, "color": calendar_colors[name]} for name in calendar_names],

--- a/static/main.css
+++ b/static/main.css
@@ -1664,6 +1664,41 @@ body.dark-mode #weather-modal-forecast-graph {
   margin-left: -3px;
 }
 
+/* Multi-day event styles */
+.week-multiday-container {
+  position: relative;
+  width: 100%;
+  transition: height 0.3s ease;
+}
+
+.month-grid-wrapper {
+  position: relative;
+}
+
+.month-multiday-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
+.multiday-event-bar {
+  position: absolute;
+  height: 20px;
+  background: var(--event-default-bg);
+  color: var(--event-default-text);
+  border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 0.75em;
+  white-space: nowrap;
+  overflow: hidden;
+  cursor: pointer;
+  pointer-events: auto;
+  transition: left 0.3s, width 0.3s, top 0.3s;
+}
+
 /* Mobile and Touch Optimizations */
 @media (max-width: 768px) {
   :root {


### PR DESCRIPTION
## Summary
- add stub multi-day events to icloud stub data
- render multi-day bars spanning days in week and month views
- add helper functions to layout multi-day bars
- style multi-day event containers and bars
- ignore node_modules and venv in git

## Testing
- `npm test`
- `pytest`