### PR TITLE
Add swipe removal with undo for meal slots

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from modules.time_module import time_bp, get_time
 from modules.network_module import network_bp, get_network
 from modules.lighting_module import lighting_bp, get_lighting
 from modules.sun_module import sun_bp, get_sun
-from modules.meals_module import meals_bp, recipes_bp
+from modules.meals_module import meals_bp, recipes_bp, mealslot_bp
 
 import os
 
@@ -44,6 +44,7 @@ app.register_blueprint(lighting_bp)
 app.register_blueprint(sun_bp)
 app.register_blueprint(meals_bp)
 app.register_blueprint(recipes_bp)
+app.register_blueprint(mealslot_bp)
 
 
 # Background task to poll data sources and emit updates

--- a/static/index.html
+++ b/static/index.html
@@ -171,6 +171,10 @@
                 <span class="material-symbols-outlined">cancel</span>
                 <span>Cancel</span>
               </button>
+              <button type="button" id="recipe-remove">
+                <span class="material-symbols-outlined">delete</span>
+                <span>Remove</span>
+              </button>
           </div>
           
           </div>
@@ -189,8 +193,12 @@
         <input type="date" id="shopping-end-date">
         <button id="generate-shopping-list">Generate List</button>
       </div>
-      <ul id="shopping-list-output"></ul>
-    </div>
+  <ul id="shopping-list-output"></ul>
+  </div>
+  </div>
+  <div id="snackbar" class="snackbar" style="display:none;">
+    <span class="snackbar-message"></span>
+    <button class="snackbar-undo">Undo</button>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="/static/meals.js"></script>

--- a/static/main.css
+++ b/static/main.css
@@ -1812,6 +1812,32 @@ body.dark-mode #weather-modal-forecast-graph {
   margin-left: -3px;
 }
 
+.snackbar {
+  position: fixed;
+  bottom: var(--space-lg);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--border-radius-card);
+  box-shadow: var(--elevation-1);
+  display: none;
+  align-items: center;
+  gap: var(--space-sm);
+  z-index: 3000;
+}
+.snackbar.show {
+  display: flex;
+}
+.snackbar-undo {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-family: var(--font-family);
+}
+
 /* Mobile and Touch Optimizations */
 @media (max-width: 768px) {
   :root {
@@ -3188,6 +3214,14 @@ body.dark-mode .meals-day-cell {
 #recipe-cancel:hover {
   filter: brightness(0.9);
 }
+#recipe-remove {
+  background: var(--color-accent-red);
+  color: var(--color-white);
+  border-radius: 6px;
+}
+#recipe-remove:hover {
+  filter: brightness(0.9);
+}
 #recipe-modal .modal-close {
   position: absolute;
   top: var(--space-sm);
@@ -3436,6 +3470,27 @@ body.dark-mode .side-panel-tab.active {
   border-radius: var(--border-radius-card);
   background: var(--color-bg-card);
   box-shadow: var(--elevation-1);
+}
+.meal-slot .delete-bg {
+  position: absolute;
+  inset: 0;
+  background: var(--color-accent-red);
+  color: var(--color-white);
+  display: flex;
+  align-items: center;
+  padding-left: var(--space-md);
+  z-index: 1;
+  pointer-events: none;
+  font-size: 28px;
+}
+.meal-slot .meal-slot-inner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.2s ease;
+  z-index: 2;
 }
 .meal-slot.breakfast { border-left: 4px solid var(--color-breakfast); }
 .meal-slot.lunch { border-left: 4px solid var(--color-lunch); }

--- a/static/main.js
+++ b/static/main.js
@@ -425,6 +425,27 @@ function renderChores(id) {
       }
     });
 
-    list.appendChild(el);
+  list.appendChild(el);
   });
 }
+
+// --- Snackbar utility ---
+let snackbarTimer = null;
+function showSnackbar(message, undoCallback) {
+  const sb = document.getElementById('snackbar');
+  if (!sb) return;
+  sb.querySelector('.snackbar-message').textContent = message + ' –';
+  const btn = sb.querySelector('.snackbar-undo');
+  btn.onclick = () => {
+    clearTimeout(snackbarTimer);
+    sb.classList.remove('show');
+    if (undoCallback) undoCallback();
+  };
+  if (snackbarTimer) clearTimeout(snackbarTimer);
+  sb.classList.add('show');
+  snackbarTimer = setTimeout(() => {
+    sb.classList.remove('show');
+    snackbarTimer = null;
+  }, 5000);
+}
+window.showSnackbar = showSnackbar;


### PR DESCRIPTION
## Summary
- add REST endpoints for deleting/restoring meal slots
- register new blueprint in app
- add remove button and snackbar container in HTML
- style swipe background, snackbar and remove button
- implement swipe-to-remove with undo and modal remove action
- expose snackbar helper

## Testing
- `npm test`
- `python -m py_compile $(git ls-files '*.py')`
