### PR TITLE
Add analog clock modal with schedule overlay

### DIFF
--- a/static/clock-modal.js
+++ b/static/clock-modal.js
@@ -1,11 +1,12 @@
 // Clock Modal functionality
 const CLOCK_TYPES = [
-  { id: 'analog', options: ['classic', 'modern'] },
+  { id: 'analog', options: ['ticks', 'roman', 'arabic', 'schedule'] },
   { id: 'digital', options: ['24h', '12h'] },
   { id: 'world',  options: ['timezone', 'map'] }
 ];
 let clockTypeIndex = 0;
 let clockOptionIndex = 0;
+let clockInterval = null;
 
 function loadClockPrefs() {
   const t = parseInt(localStorage.getItem('clockTypeIndex')); 
@@ -42,6 +43,9 @@ function openClockModal() {
 function closeClockModal() {
   const overlay = document.getElementById('clock-modal-overlay');
   overlay.classList.remove('open');
+  stopAnalogClock();
+  const editor = overlay.querySelector('.schedule-editor');
+  if (editor) editor.remove();
 }
 
 function cycleClockType(dir) {
@@ -87,8 +91,194 @@ function renderClockModal() {
   const display = overlay.querySelector('.clock-modal-display');
   const type = CLOCK_TYPES[clockTypeIndex];
   const option = type.options[clockOptionIndex];
-  display.innerHTML = `<div class="clock-placeholder">${type.id} - ${option}</div>`;
+  stopAnalogClock();
+  if (type.id === 'analog') {
+    display.innerHTML = getAnalogClockHtml(option);
+    startAnalogClock();
+    const editBtn = display.querySelector('.edit-schedule-btn');
+    if (editBtn) editBtn.addEventListener('click', openScheduleEditor);
+  } else {
+    display.innerHTML = `<div class="clock-placeholder">${type.id} - ${option}</div>`;
+  }
   saveClockPrefs();
+}
+
+function startAnalogClock() {
+  updateAnalogTime();
+  clockInterval = setInterval(updateAnalogTime, 1000);
+}
+
+function stopAnalogClock() {
+  if (clockInterval) {
+    clearInterval(clockInterval);
+    clockInterval = null;
+  }
+}
+
+function updateAnalogTime() {
+  const overlay = document.getElementById('clock-modal-overlay');
+  const hourHand = overlay.querySelector('.clock-hand.hour');
+  if (!hourHand) return;
+  const now = new Date();
+  const sec = now.getSeconds();
+  const min = now.getMinutes() + sec / 60;
+  const hr = now.getHours() % 12 + min / 60;
+  hourHand.setAttribute('transform', `rotate(${hr * 30} 100 100)`);
+  const minHand = overlay.querySelector('.clock-hand.minute');
+  const secHand = overlay.querySelector('.clock-hand.second');
+  if (minHand) minHand.setAttribute('transform', `rotate(${min * 6} 100 100)`);
+  if (secHand) secHand.setAttribute('transform', `rotate(${sec * 6} 100 100)`);
+  const dateEl = overlay.querySelector('.clock-date');
+  if (dateEl) dateEl.textContent = now.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric'
+  });
+}
+
+function romanNumeral(n) {
+  const romans = ['I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII'];
+  return romans[(n - 1) % 12];
+}
+
+function arcPath(start, end, outer, inner, color) {
+  const large = end - start > Math.PI ? 1 : 0;
+  const sx = 100 + outer * Math.sin(start);
+  const sy = 100 - outer * Math.cos(start);
+  const ex = 100 + outer * Math.sin(end);
+  const ey = 100 - outer * Math.cos(end);
+  const ix = 100 + inner * Math.sin(end);
+  const iy = 100 - inner * Math.cos(end);
+  const sx2 = 100 + inner * Math.sin(start);
+  const sy2 = 100 - inner * Math.cos(start);
+  return `<path d="M ${sx} ${sy} A ${outer} ${outer} 0 ${large} 1 ${ex} ${ey} L ${ix} ${iy} A ${inner} ${inner} 0 ${large} 0 ${sx2} ${sy2} Z" fill="${color}" />`;
+}
+
+function loadSchedule() {
+  try {
+    const s = JSON.parse(localStorage.getItem('clockSchedule'));
+    if (Array.isArray(s)) return s;
+  } catch(e) {}
+  return [
+    { time: '07:00', label: 'Wake Up', color: '#3B82F6' },
+    { time: '08:00', label: 'Breakfast', color: '#FACC15' },
+    { time: '12:00', label: 'Lunch', color: '#10B981' },
+    { time: '18:00', label: 'Dinner', color: '#F97316' },
+    { time: '22:00', label: 'Bedtime', color: '#8B5CF6' }
+  ];
+}
+
+function saveSchedule(s) {
+  localStorage.setItem('clockSchedule', JSON.stringify(s));
+}
+
+function getAnalogClockHtml(style) {
+  const dateStr = new Date().toLocaleDateString(undefined, { weekday:'long', month:'long', day:'numeric' });
+  const showNumbers = style === 'roman' || style === 'arabic';
+  let nums = '';
+  if (showNumbers) {
+    for (let i=1;i<=12;i++) {
+      const ang = (i/12) * Math.PI * 2;
+      const x = 100 + 80 * Math.sin(ang);
+      const y = 100 - 80 * Math.cos(ang);
+      const label = style === 'roman' ? romanNumeral(i) : i;
+      nums += `<text class="clock-num" x="${x}" y="${y}" text-anchor="middle" dominant-baseline="middle">${label}</text>`;
+    }
+  }
+  let ticks = '';
+  for (let i=0;i<60;i++) {
+    const ang = (i/60) * Math.PI * 2;
+    const inner = i%5===0 ? 88 : 92;
+    const outer = 96;
+    const x1 = 100 + inner * Math.sin(ang);
+    const y1 = 100 - inner * Math.cos(ang);
+    const x2 = 100 + outer * Math.sin(ang);
+    const y2 = 100 - outer * Math.cos(ang);
+    ticks += `<line class="clock-tick${i%5===0?' major':''}" x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" />`;
+  }
+  let arcs = '';
+  if (style === 'schedule') {
+    const schedule = loadSchedule();
+    const seg = Math.PI/6;
+    schedule.forEach(item=>{
+      const [h,m] = item.time.split(':').map(Number);
+      const mins = h*60 + m;
+      const ang = (mins/720) * Math.PI * 2;
+      arcs += arcPath(ang - seg/2, ang + seg/2, 98, 82, item.color);
+    });
+  }
+  return `
+  <div class="analog-clock-wrapper">
+    <svg class="analog-clock" viewBox="0 0 200 200">
+      <g class="schedule-arcs">${arcs}</g>
+      <circle class="clock-face" cx="100" cy="100" r="98" />
+      <g class="clock-ticks">${ticks}</g>
+      <g class="clock-numbers">${nums}</g>
+      <line class="clock-hand hour" x1="100" y1="100" x2="100" y2="60" />
+      <line class="clock-hand minute" x1="100" y1="100" x2="100" y2="40" />
+      <line class="clock-hand second" x1="100" y1="105" x2="100" y2="30" />
+    </svg>
+    <div class="clock-date">${dateStr}</div>
+    ${style === 'schedule' ? '<button class="edit-schedule-btn">Edit Schedule</button>' : ''}
+  </div>`;
+}
+
+function openScheduleEditor() {
+  const overlay = document.getElementById('clock-modal-overlay');
+  if (overlay.querySelector('.schedule-editor')) return;
+  const container = document.createElement('div');
+  container.className = 'schedule-editor';
+  const schedule = loadSchedule();
+  container.innerHTML = `<div class="schedule-items"></div>
+    <button type="button" class="add-item">Add</button>
+    <div class="schedule-actions">
+      <button type="button" class="save-schedule">Save</button>
+      <button type="button" class="cancel-schedule">Cancel</button>
+    </div>`;
+  overlay.querySelector('.clock-modal-content').appendChild(container);
+  const list = container.querySelector('.schedule-items');
+
+  function renderItems() {
+    list.innerHTML = '';
+    schedule.forEach((it,idx)=>{
+      const div=document.createElement('div');
+      div.className='schedule-item';
+      div.innerHTML=`<input type="time" value="${it.time}">
+        <input type="text" value="${it.label}" placeholder="Label">
+        <input type="color" value="${it.color}">
+        <button type="button" class="remove-item" data-idx="${idx}">&times;</button>`;
+      list.appendChild(div);
+    });
+  }
+
+  renderItems();
+
+  container.addEventListener('click',e=>{
+    if(e.target.classList.contains('remove-item')){
+      const i=parseInt(e.target.getAttribute('data-idx'));
+      schedule.splice(i,1);
+      renderItems();
+    }
+  });
+
+  container.querySelector('.add-item').addEventListener('click',()=>{
+    schedule.push({time:'12:00',label:'',color:'#3B82F6'});
+    renderItems();
+  });
+
+  container.querySelector('.cancel-schedule').addEventListener('click',()=>{
+    container.remove();
+  });
+
+  container.querySelector('.save-schedule').addEventListener('click',()=>{
+    const items = Array.from(list.querySelectorAll('.schedule-item')).map(div=>{
+      const inputs = div.querySelectorAll('input');
+      return {time:inputs[0].value,label:inputs[1].value,color:inputs[2].value};
+    });
+    saveSchedule(items);
+    container.remove();
+    renderClockModal();
+  });
 }
 
 function trapFocus(container) {

--- a/static/clock-modal.js
+++ b/static/clock-modal.js
@@ -315,8 +315,8 @@ function getAnalogClockHtml(style) {
       <g class="clock-numbers">${nums}</g>
       <g class="schedule-labels">${arcLabels}</g>
       <line class="clock-hand hour" x1="100" y1="100" x2="100" y2="68" />
-      <line class="clock-hand minute" x1="100" y1="100" x2="100" y2="48" />
-      <line class="clock-hand second" x1="100" y1="100" x2="100" y2="36" />
+      <line class="clock-hand minute" x1="100" y1="100" x2="100" y2="42" />
+      <line class="clock-hand second" x1="100" y1="100" x2="100" y2="20" />
     </svg>
     <div class="clock-date">${dateStr}</div>
     ${

--- a/static/clock-modal.js
+++ b/static/clock-modal.js
@@ -263,17 +263,19 @@ function getAnalogClockHtml(style) {
     }
   }
   let ticks = "";
-  for (let i = 0; i < 60; i++) {
-    const ang = (i / 60) * Math.PI * 2;
-    const inner = i % 5 === 0 ? 88 : 92;
-    const outer = 96;
-    const x1 = 100 + inner * Math.sin(ang);
-    const y1 = 100 - inner * Math.cos(ang);
-    const x2 = 100 + outer * Math.sin(ang);
-    const y2 = 100 - outer * Math.cos(ang);
-    ticks += `<line class="clock-tick${
-      i % 5 === 0 ? " major" : ""
-    }" x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" />`;
+  if (style !== "schedule") {
+    for (let i = 0; i < 60; i++) {
+      const ang = (i / 60) * Math.PI * 2;
+      const inner = i % 5 === 0 ? 88 : 92;
+      const outer = 96;
+      const x1 = 100 + inner * Math.sin(ang);
+      const y1 = 100 - inner * Math.cos(ang);
+      const x2 = 100 + outer * Math.sin(ang);
+      const y2 = 100 - outer * Math.cos(ang);
+      ticks += `<line class="clock-tick${
+        i % 5 === 0 ? " major" : ""
+      }" x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" />`;
+    }
   }
   let arcs = "";
   let arcLabels = "";

--- a/static/clock-modal.js
+++ b/static/clock-modal.js
@@ -246,7 +246,7 @@ function getAnalogClockHtml(style) {
     for (let i = step; i <= maxNum; i += step) {
       const displayHour = is24Hour ? i : i;
       const ang = is24Hour ? (i / 24) * Math.PI * 2 : (i / 12) * Math.PI * 2;
-      const radius = is24Hour ? 85 : 80; // Slightly closer for 24h to fit more numbers
+      const radius = is24Hour ? 70 : 65; // reduced radius for numbers
       const x = 100 + radius * Math.sin(ang);
       const y = 100 - radius * Math.cos(ang);
 
@@ -264,8 +264,8 @@ function getAnalogClockHtml(style) {
   if (style !== "schedule") {
     for (let i = 0; i < 60; i++) {
       const ang = (i / 60) * Math.PI * 2;
-      const inner = i % 5 === 0 ? 88 : 92;
-      const outer = 96;
+      const inner = i % 5 === 0 ? 75 : 79; // reduced
+      const outer = 83; // reduced
       const x1 = 100 + inner * Math.sin(ang);
       const y1 = 100 - inner * Math.cos(ang);
       const x2 = 100 + outer * Math.sin(ang);
@@ -280,10 +280,9 @@ function getAnalogClockHtml(style) {
   let arcPaths = "";
   if (style === "schedule") {
     const schedule = loadSchedule();
-    // Use CSS variables for margin and thickness
-    const arcMargin = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--clock-arc-margin')) || 8;
-    const arcThickness = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--clock-arc-thickness')) || 14;
-    const baseRadius = 98 + arcMargin + arcThickness / 2; // Place arc just outside clock face
+    const arcMargin = 4; // reduced
+    const arcThickness = 2; // reduced
+    const baseRadius = 90; // reduced, fits inside 200x200
     const seg = Math.PI / 12;
     schedule.forEach((item, index) => {
       const [h, m] = item.time.split(":").map(Number);
@@ -311,13 +310,13 @@ function getAnalogClockHtml(style) {
         ${arcPaths}
       </defs>
       <g class="schedule-arcs">${arcs}</g>
-      <circle class="clock-face" cx="100" cy="100" r="98" />
+      <circle class="clock-face" cx="100" cy="100" r="80" />
       <g class="clock-ticks">${ticks}</g>
       <g class="clock-numbers">${nums}</g>
       <g class="schedule-labels">${arcLabels}</g>
-      <line class="clock-hand hour" x1="100" y1="100" x2="100" y2="60" />
-      <line class="clock-hand minute" x1="100" y1="100" x2="100" y2="40" />
-      <line class="clock-hand second" x1="100" y1="100" x2="100" y2="30" />
+      <line class="clock-hand hour" x1="100" y1="100" x2="100" y2="68" />
+      <line class="clock-hand minute" x1="100" y1="100" x2="100" y2="48" />
+      <line class="clock-hand second" x1="100" y1="100" x2="100" y2="36" />
     </svg>
     <div class="clock-date">${dateStr}</div>
     ${

--- a/static/main.css
+++ b/static/main.css
@@ -4897,9 +4897,10 @@ body.dark-mode #weather-modal-forecast-graph {
   gap: var(--space-sm);
 }
 .analog-clock {
-  width: 80%;
-  height: auto;
-  max-height: 80vh;
+  width: min(90vw, 90vh, 100%);
+  height: min(90vw, 90vh, 100%);
+  max-width: 500px;
+  max-height: 500px;
 }
 .clock-face {
   fill: none;
@@ -4923,6 +4924,15 @@ body.dark-mode #weather-modal-forecast-graph {
 .clock-hand.minute { stroke-width: 2; }
 .clock-hand.second { stroke-width: 1; stroke: var(--color-accent-red); }
 .schedule-arcs path { opacity: 0.5; }
+.schedule-label {
+  font-size: 10px;
+  fill: var(--text-color);
+  font-family: var(--font-family);
+  font-weight: 500;
+  pointer-events: none;
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
 .clock-date {
   font-size: 1.2em;
 }

--- a/static/main.css
+++ b/static/main.css
@@ -51,6 +51,8 @@
   --event-birthday-text: #111827;
   --event-default-bg: var(--color-gray);
   --event-default-text: #fff;
+  --clock-arc-margin: 8px;
+  --clock-arc-thickness: 14px;
 }
 body.dark-mode {
   --color-bg: #111827;
@@ -4854,7 +4856,7 @@ body.dark-mode #weather-modal-forecast-graph {
   box-shadow: 0 5px 20px rgba(0,0,0,0.2);
   width: 90vw;
   height: 90vh;
-  max-width: 600px;
+  max-width: 90vh;
   max-height: 90vh;
   display: flex;
   align-items: center;
@@ -4923,7 +4925,12 @@ body.dark-mode #weather-modal-forecast-graph {
 .clock-hand.hour { stroke-width: 3; }
 .clock-hand.minute { stroke-width: 2; }
 .clock-hand.second { stroke-width: 1; stroke: var(--color-accent-red); }
-.schedule-arcs path { opacity: 0.5; }
+.schedule-arcs path {
+  fill: none;
+  stroke-width: var(--clock-arc-thickness);
+  stroke-linecap: round;
+  stroke-opacity: 0.7;
+}
 .schedule-label {
   font-size: 10px;
   fill: var(--text-color);

--- a/static/main.css
+++ b/static/main.css
@@ -4886,3 +4886,79 @@ body.dark-mode #weather-modal-forecast-graph {
   transform: translateX(-50%);
 }
 
+/* Analog Clock Styles */
+.analog-clock-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  gap: var(--space-sm);
+}
+.analog-clock {
+  width: 80%;
+  height: auto;
+  max-height: 80vh;
+}
+.clock-face {
+  fill: none;
+  stroke: var(--text-color);
+  stroke-width: 2;
+}
+.clock-tick {
+  stroke: var(--text-color);
+  stroke-width: 1;
+}
+.clock-tick.major { stroke-width: 2; }
+.clock-num {
+  font-size: 12px;
+  fill: var(--text-color);
+}
+.clock-hand {
+  stroke: var(--text-color);
+  stroke-linecap: round;
+  transform-origin: 100px 100px;
+}
+.clock-hand.hour { stroke-width: 3; }
+.clock-hand.minute { stroke-width: 2; }
+.clock-hand.second { stroke-width: 1; stroke: var(--color-accent-red); }
+.schedule-arcs path { opacity: 0.5; }
+.clock-date {
+  font-size: 1.2em;
+}
+.edit-schedule-btn {
+  padding: var(--space-xs) var(--space-sm);
+  border: none;
+  border-radius: var(--border-radius-btn);
+  background: var(--color-primary);
+  color: var(--color-white);
+  cursor: pointer;
+}
+.schedule-editor {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--widget-bg);
+  color: var(--text-color);
+  border-radius: var(--border-radius-card);
+  box-shadow: 0 5px 20px rgba(0,0,0,0.2);
+  padding: var(--space-md);
+  z-index: 3050;
+  width: 80%;
+  max-width: 300px;
+}
+.schedule-editor .schedule-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-xs);
+}
+.schedule-editor .schedule-actions {
+  margin-top: var(--space-sm);
+  display: flex;
+  gap: var(--space-xs);
+  justify-content: flex-end;
+}
+

--- a/static/main.css
+++ b/static/main.css
@@ -4901,8 +4901,8 @@ body.dark-mode #weather-modal-forecast-graph {
 .analog-clock {
   width: min(90vw, 90vh, 100%);
   height: min(90vw, 90vh, 100%);
-  min-width: 500px;
-  min-height: 500px;
+  min-width: 800px;
+  min-height: 800px;
 }
 .clock-face {
   fill: none;
@@ -4932,10 +4932,10 @@ body.dark-mode #weather-modal-forecast-graph {
   stroke-opacity: 0.7;
 }
 .schedule-label {
-  font-size: 10px;
+  font-size: 5px;
   fill: var(--text-color);
   font-family: var(--font-family);
-  font-weight: 500;
+  font-weight: 300;
   pointer-events: none;
   text-anchor: middle;
   dominant-baseline: middle;

--- a/static/main.css
+++ b/static/main.css
@@ -4899,13 +4899,13 @@ body.dark-mode #weather-modal-forecast-graph {
 .analog-clock {
   width: min(90vw, 90vh, 100%);
   height: min(90vw, 90vh, 100%);
-  max-width: 500px;
-  max-height: 500px;
+  min-width: 500px;
+  min-height: 500px;
 }
 .clock-face {
   fill: none;
   stroke: var(--text-color);
-  stroke-width: 2;
+  stroke-width: 1;
 }
 .clock-tick {
   stroke: var(--text-color);

--- a/static/main.css
+++ b/static/main.css
@@ -4918,7 +4918,6 @@ body.dark-mode #weather-modal-forecast-graph {
 .clock-hand {
   stroke: var(--text-color);
   stroke-linecap: round;
-  transform-origin: 100px 100px;
 }
 .clock-hand.hour { stroke-width: 3; }
 .clock-hand.minute { stroke-width: 2; }


### PR DESCRIPTION
## Summary
- integrate analog clock type with options for ticks, numerals and schedule
- draw clock face & hands in SVG and animate every second
- allow editing of schedule items stored in localStorage
- style analog clock and editor per design variables

## Testing
- `npm test`
- `pytest -q`
